### PR TITLE
✨이메일+비밀번호 기반 로그인 구현

### DIFF
--- a/src/main/kotlin/onku/backend/domain/member/Member.kt
+++ b/src/main/kotlin/onku/backend/domain/member/Member.kt
@@ -15,6 +15,9 @@ class Member(
     @Column(nullable = false, unique = true, length = 255)
     var email: String? = null,
 
+    @Column(name = "password", nullable = true, length = 255)
+    var password: String? = null,
+
     @Enumerated(EnumType.STRING)
     @Column(nullable = false, length = 20)
     var role: Role = Role.USER,

--- a/src/main/kotlin/onku/backend/domain/member/MemberErrorCode.kt
+++ b/src/main/kotlin/onku/backend/domain/member/MemberErrorCode.kt
@@ -12,4 +12,5 @@ enum class MemberErrorCode(
     INVALID_MEMBER_STATE("MEMBER409", "현재 상태에서는 요청한 상태 변경을 수행할 수 없습니다.", HttpStatus.CONFLICT),
     PAGE_MEMBERS_NOT_FOUND("MEMBER404_PAGE", "조회할 수 있는 회원이 없습니다.", HttpStatus.NOT_FOUND),
     INVALID_REQUEST("MEMBER400", "요청 값이 올바르지 않습니다.", HttpStatus.BAD_REQUEST),
+    DUPLICATE_EMAIL("MEMBER409_DUP_EMAIL", "이미 사용 중인 이메일입니다.", HttpStatus.CONFLICT),
 }

--- a/src/main/kotlin/onku/backend/domain/member/controller/user/MemberUserController.kt
+++ b/src/main/kotlin/onku/backend/domain/member/controller/user/MemberUserController.kt
@@ -23,6 +23,13 @@ class MemberUserController(
     private val memberService: MemberService,
     private val memberAlarmHistoryService: MemberAlarmHistoryService,
 ) {
+    @PostMapping("/register")
+    @Operation(summary = "회원가입", description = "이메일과 비밀번호로 회원가입 후 온보딩 토큰을 헤더에 담아 반환합니다.")
+    fun registerMember(
+        @RequestBody @Valid req: MemberRegisterRequest
+    ): ResponseEntity<SuccessResponse<MemberResponse>> =
+        memberService.register(req)
+
     @PostMapping("/onboarding")
     @ResponseStatus(HttpStatus.ACCEPTED)
     @Operation(

--- a/src/main/kotlin/onku/backend/domain/member/dto/MemberRegisterRequest.kt
+++ b/src/main/kotlin/onku/backend/domain/member/dto/MemberRegisterRequest.kt
@@ -1,0 +1,4 @@
+package onku.backend.domain.member.dto
+
+class MemberRegisterRequest {
+}

--- a/src/main/kotlin/onku/backend/domain/member/dto/MemberRegisterRequest.kt
+++ b/src/main/kotlin/onku/backend/domain/member/dto/MemberRegisterRequest.kt
@@ -1,4 +1,18 @@
 package onku.backend.domain.member.dto
 
-class MemberRegisterRequest {
-}
+import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.constraints.Email
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.Size
+
+data class MemberRegisterRequest(
+    @field:Email(message = "올바른 이메일 형식이어야 합니다.")
+    @field:NotBlank(message = "이메일은 필수입니다.")
+    @Schema(example = "test@gmail.com")
+    val email: String,
+
+    @field:NotBlank(message = "비밀번호는 필수입니다.")
+    @field:Size(min = 8, max = 64, message = "비밀번호는 8~64자여야 합니다.")
+    @Schema(example = "test1234")
+    val password: String
+)

--- a/src/main/kotlin/onku/backend/domain/member/dto/MemberResponse.kt
+++ b/src/main/kotlin/onku/backend/domain/member/dto/MemberResponse.kt
@@ -1,0 +1,4 @@
+package onku.backend.domain.member.dto
+
+class MemberResponse {
+}

--- a/src/main/kotlin/onku/backend/domain/member/dto/MemberResponse.kt
+++ b/src/main/kotlin/onku/backend/domain/member/dto/MemberResponse.kt
@@ -1,4 +1,24 @@
 package onku.backend.domain.member.dto
 
-class MemberResponse {
+import onku.backend.domain.member.Member
+import onku.backend.domain.member.enums.ApprovalStatus
+import onku.backend.domain.member.enums.Role
+
+data class MemberResponse(
+    val memberId: Long,
+    val email: String,
+    val role: Role,
+    val approval: ApprovalStatus,
+    val hasInfo: Boolean
+) {
+    companion object {
+        fun of(member: Member): MemberResponse =
+            MemberResponse(
+                memberId = member.id!!,
+                email = member.email!!,
+                role = member.role,
+                approval = member.approval,
+                hasInfo = member.hasInfo
+            )
+    }
 }

--- a/src/main/kotlin/onku/backend/domain/member/enums/SocialType.kt
+++ b/src/main/kotlin/onku/backend/domain/member/enums/SocialType.kt
@@ -8,5 +8,6 @@ import io.swagger.v3.oas.annotations.media.Schema
 )
 enum class SocialType {
     @Schema(description = "카카오") KAKAO,
-    @Schema(description = "애플") APPLE
+    @Schema(description = "애플") APPLE,
+    @Schema(description = "이메일") EMAIL,
 }

--- a/src/main/kotlin/onku/backend/global/auth/AuthErrorCode.kt
+++ b/src/main/kotlin/onku/backend/global/auth/AuthErrorCode.kt
@@ -19,5 +19,6 @@ enum class AuthErrorCode(
     APPLE_API_COMMUNICATION_ERROR("AUTH502", "애플 API 통신 중 오류가 발생했습니다.", HttpStatus.BAD_GATEWAY),
     APPLE_TOKEN_EMPTY_RESPONSE("AUTH502", "애플 토큰 응답이 비어 있습니다.", HttpStatus.BAD_GATEWAY),
     APPLE_ID_TOKEN_INVALID("AUTH401", "유효하지 않은 애플 ID 토큰입니다.", HttpStatus.UNAUTHORIZED),
-    APPLE_JWKS_FETCH_FAILED("AUTH502", "애플 공개 키(JWKS)를 불러오는 데 실패했습니다.", HttpStatus.BAD_GATEWAY)
+    APPLE_JWKS_FETCH_FAILED("AUTH502", "애플 공개 키(JWKS)를 불러오는 데 실패했습니다.", HttpStatus.BAD_GATEWAY),
+    INVALID_EMAIL_OR_PASSWORD("AUTH401", "이메일 또는 비밀번호가 올바르지 않습니다.", HttpStatus.UNAUTHORIZED)
 }

--- a/src/main/kotlin/onku/backend/global/auth/config/SecurityConfig.kt
+++ b/src/main/kotlin/onku/backend/global/auth/config/SecurityConfig.kt
@@ -9,6 +9,8 @@ import org.springframework.context.annotation.Configuration
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
 import org.springframework.security.config.http.SessionCreationPolicy
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder
+import org.springframework.security.crypto.password.PasswordEncoder
 import org.springframework.security.web.SecurityFilterChain
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter
 
@@ -30,6 +32,8 @@ class SecurityConfig(
             "/api/v1/auth/kakao",
             "/api/v1/auth/apple",
             "/api/v1/auth/reissue",
+            "/api/v1/members/register",
+            "/api/v1/auth/login"
         )
 
         private val ONBOARDING_ENDPOINT = arrayOf( // (GUEST)
@@ -54,6 +58,9 @@ class SecurityConfig(
             "/api/v1/members/executive/**",
         )
     }
+
+    @Bean
+    fun passwordEncoder(): PasswordEncoder = BCryptPasswordEncoder()
 
     @Bean
     fun filterChain(http: HttpSecurity, corsConfiguration: CustomCorsConfig): SecurityFilterChain {

--- a/src/main/kotlin/onku/backend/global/auth/controller/AuthController.kt
+++ b/src/main/kotlin/onku/backend/global/auth/controller/AuthController.kt
@@ -2,10 +2,12 @@ package onku.backend.global.auth.controller
 
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
+import jakarta.validation.Valid
 import onku.backend.domain.member.Member
 import onku.backend.global.annotation.CurrentMember
 import onku.backend.global.auth.dto.AppleLoginRequest
 import onku.backend.global.auth.dto.AuthLoginResult
+import onku.backend.global.auth.dto.EmailLoginRequest
 import onku.backend.global.auth.dto.KakaoLoginRequest
 import onku.backend.global.auth.service.AuthService
 import onku.backend.global.response.SuccessResponse
@@ -18,6 +20,13 @@ import org.springframework.web.bind.annotation.*
 class AuthController(
     private val authService: AuthService,
 ) {
+    @PostMapping("/login")
+    @Operation(summary = "이메일 로그인", description = "이메일과 비밀번호로 로그인 후 JWT 토큰을 헤더에 담아 반환합니다.")
+    fun emailLogin(
+        @RequestBody @Valid req: EmailLoginRequest
+    ): ResponseEntity<SuccessResponse<AuthLoginResult>> =
+        authService.emailLogin(req)
+
     @PostMapping("/kakao")
     @Operation(summary = "카카오 로그인", description = "인가코드를 body로 받아 사용자를 식별합니다.")
     fun kakaoLogin(@RequestBody req: KakaoLoginRequest): ResponseEntity<SuccessResponse<AuthLoginResult>> =

--- a/src/main/kotlin/onku/backend/global/auth/dto/EmailLoginRequest.kt
+++ b/src/main/kotlin/onku/backend/global/auth/dto/EmailLoginRequest.kt
@@ -1,0 +1,4 @@
+package onku.backend.global.auth.dto
+
+class EmailLoginRequest {
+}

--- a/src/main/kotlin/onku/backend/global/auth/dto/EmailLoginRequest.kt
+++ b/src/main/kotlin/onku/backend/global/auth/dto/EmailLoginRequest.kt
@@ -1,4 +1,16 @@
 package onku.backend.global.auth.dto
 
-class EmailLoginRequest {
-}
+import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.constraints.Email
+import jakarta.validation.constraints.NotBlank
+
+data class EmailLoginRequest(
+    @field:Email(message = "올바른 이메일 형식이어야 합니다.")
+    @field:NotBlank(message = "이메일은 필수입니다.")
+    @Schema(example = "test@gmail.com")
+    val email: String,
+
+    @field:NotBlank(message = "비밀번호는 필수입니다.")
+    @Schema(example = "test1234")
+    val password: String
+)

--- a/src/main/kotlin/onku/backend/global/auth/service/AuthService.kt
+++ b/src/main/kotlin/onku/backend/global/auth/service/AuthService.kt
@@ -3,11 +3,13 @@ package onku.backend.global.auth.service
 import onku.backend.domain.member.Member
 import onku.backend.global.auth.dto.AppleLoginRequest
 import onku.backend.global.auth.dto.AuthLoginResult
+import onku.backend.global.auth.dto.EmailLoginRequest
 import onku.backend.global.auth.dto.KakaoLoginRequest
 import onku.backend.global.response.SuccessResponse
 import org.springframework.http.ResponseEntity
 
 interface AuthService {
+    fun emailLogin(dto: EmailLoginRequest): ResponseEntity<SuccessResponse<AuthLoginResult>>
     fun kakaoLogin(dto: KakaoLoginRequest): ResponseEntity<SuccessResponse<AuthLoginResult>>
     fun appleLogin(dto: AppleLoginRequest): ResponseEntity<SuccessResponse<AuthLoginResult>>
     fun reissueAccessToken(refreshToken: String): ResponseEntity<SuccessResponse<String>>


### PR DESCRIPTION
### ✨ Related Issue
- #182 
---

### 📌 Task Details
- 로그인, 회원가입 구현

---

### 💬 Review Requirements (Optional)
- 회원가입 시 온보딩 토큰을 헤더에서 반환합니다. 이후 로그인 성공 시에는 status에 따라 `PENDING` 상태이면 온보딩 토큰을, `APPROVED` 상태이면 일반 access token을 반환합니다. 
